### PR TITLE
There is an update available.

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -26,49 +26,44 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for new version
+      - name: Check for new version (oslook/cursor-ai-downloads)
         id: check
         run: |
-          # Fetch latest version info from Cursor API for both architectures
-          X64_RESPONSE=$(curl -s -f -L --compressed "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable" 2>/dev/null | awk '/^{.*}$/{print; exit}')
-          ARM64_RESPONSE=$(curl -s -f -L --compressed "https://www.cursor.com/api/download?platform=linux-arm64&releaseTrack=stable" 2>/dev/null | awk '/^{.*}$/{print; exit}')
-
-          echo "X64_RESPONSE: $X64_RESPONSE"
-          echo "ARM64_RESPONSE: $ARM64_RESPONSE"
-
-          # Ensure responses are not empty
-          if [ -z "$X64_RESPONSE" ]; then
-            echo "Error: X64_RESPONSE is empty."
-            exit 1
-          fi
-          if [ -z "$ARM64_RESPONSE" ]; then
-            echo "Error: ARM64_RESPONSE is empty."
+          echo "Fetching latest version info from oslook/cursor-ai-downloads repository..."
+          
+          # Fetch the version history JSON
+          JSON_DATA=$(curl -sL "https://raw.githubusercontent.com/oslook/cursor-ai-downloads/main/version-history.json")
+          
+          if [ -z "$JSON_DATA" ]; then
+            echo "Error: Failed to download version-history.json."
             exit 1
           fi
 
-          VERSION=$(echo "$X64_RESPONSE" | jq -r '.version')
-          X64_DOWNLOAD_URL=$(echo "$X64_RESPONSE" | jq -r '.downloadUrl')
-          ARM64_DOWNLOAD_URL=$(echo "$ARM64_RESPONSE" | jq -r '.downloadUrl')
-          COMMIT_SHA=$(echo "$X64_RESPONSE" | jq -r '.commitSha')
+          # Get the latest entry (the first one in the array)
+          LATEST_ENTRY=$(echo "$JSON_DATA" | jq -c '.versions[0]')
+          
+          # Extract the required information using jq
+          VERSION=$(echo "$LATEST_ENTRY" | jq -r '.version')
+          X64_DOWNLOAD_URL=$(echo "$LATEST_ENTRY" | jq -r '.platforms["linux-x64"]')
+          ARM64_DOWNLOAD_URL=$(echo "$LATEST_ENTRY" | jq -r '.platforms["linux-arm64"]')
+          # Commit SHA is not available in this data source
+          COMMIT_SHA="N/A"
 
-          # Ensure variables are not empty after jq parsing
-          if [ -z "$VERSION" ]; then
+          # Ensure variables are not empty after parsing
+          if [ -z "$VERSION" ] || [ "$VERSION" == "null" ]; then
             echo "Error: VERSION is empty after parsing."
             exit 1
           fi
-          if [ -z "$X64_DOWNLOAD_URL" ]; then
+          if [ -z "$X64_DOWNLOAD_URL" ] || [ "$X64_DOWNLOAD_URL" == "null" ]; then
             echo "Error: X64_DOWNLOAD_URL is empty after parsing."
             exit 1
           fi
-          if [ -z "$ARM64_DOWNLOAD_URL" ]; then
+          if [ -z "$ARM64_DOWNLOAD_URL" ] || [ "$ARM64_DOWNLOAD_URL" == "null" ]; then
             echo "Error: ARM64_DOWNLOAD_URL is empty after parsing."
             exit 1
           fi
-          if [ -z "$COMMIT_SHA" ]; then
-            echo "Error: COMMIT_SHA is empty after parsing."
-            exit 1
-          fi
 
+          echo "Latest Version Found: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "x64_download_url=$X64_DOWNLOAD_URL" >> $GITHUB_OUTPUT
           echo "arm64_download_url=$ARM64_DOWNLOAD_URL" >> $GITHUB_OUTPUT

--- a/latest-release.json
+++ b/latest-release.json
@@ -1,15 +1,15 @@
 {
-  "version": "1.2.2",
-  "commit_sha": "faa03b17cce93e8a80b7d62d57f5eda6bb6ab9fa",
-  "release_date": "2025-07-08T03:19:29Z",
+  "version": "1.2.4",
+  "commit_sha": "N/A",
+  "release_date": "2025-07-13T06:07:32Z",
   "packages": {
     "x64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor_1.2.2_amd64.deb",
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor-1.2.2-1.x86_64.rpm"
+      "deb": "https://github.com/yjavaherian/cursor-linux-packages/releases/download/v1.2.4/cursor_1.2.4_amd64.deb",
+      "rpm": "https://github.com/yjavaherian/cursor-linux-packages/releases/download/v1.2.4/cursor-1.2.4-1.x86_64.rpm"
     },
     "arm64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor_1.2.2_arm64.deb", 
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor-1.2.2-1.aarch64.rpm"
+      "deb": "https://github.com/yjavaherian/cursor-linux-packages/releases/download/v1.2.4/cursor_1.2.4_arm64.deb", 
+      "rpm": "https://github.com/yjavaherian/cursor-linux-packages/releases/download/v1.2.4/cursor-1.2.4-1.aarch64.rpm"
     }
   }
 }

--- a/latest-release.json
+++ b/latest-release.json
@@ -1,15 +1,15 @@
 {
-  "version": "1.2.1",
-  "commit_sha": "031e7e0ff1e2eda9c1a0f5df67d44053b059c5df",
-  "release_date": "2025-07-05T07:42:22Z",
+  "version": "1.2.2",
+  "commit_sha": "faa03b17cce93e8a80b7d62d57f5eda6bb6ab9fa",
+  "release_date": "2025-07-08T03:19:29Z",
   "packages": {
     "x64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor_1.2.1_amd64.deb",
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor-1.2.1-1.x86_64.rpm"
+      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor_1.2.2_amd64.deb",
+      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor-1.2.2-1.x86_64.rpm"
     },
     "arm64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor_1.2.1_arm64.deb", 
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor-1.2.1-1.aarch64.rpm"
+      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor_1.2.2_arm64.deb", 
+      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.2/cursor-1.2.2-1.aarch64.rpm"
     }
   }
 }

--- a/latest-release.json
+++ b/latest-release.json
@@ -1,15 +1,15 @@
 {
-  "version": "1.0.0",
-  "commit_sha": "53b99ce608cba35127ae3a050c1738a959750865",
-  "release_date": "2025-06-10T10:13:08Z",
+  "version": "1.2.1",
+  "commit_sha": "031e7e0ff1e2eda9c1a0f5df67d44053b059c5df",
+  "release_date": "2025-07-05T07:42:22Z",
   "packages": {
     "x64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.0.0/cursor_1.0.0_amd64.deb",
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.0.0/cursor-1.0.0-1.x86_64.rpm"
+      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor_1.2.1_amd64.deb",
+      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor-1.2.1-1.x86_64.rpm"
     },
     "arm64": {
-      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.0.0/cursor_1.0.0_arm64.deb", 
-      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.0.0/cursor-1.0.0-1.aarch64.rpm"
+      "deb": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor_1.2.1_arm64.deb", 
+      "rpm": "https://github.com/PaperBoardOfficial/cursor-linux-packages/releases/download/v1.2.1/cursor-1.2.1-1.aarch64.rpm"
     }
   }
 }


### PR DESCRIPTION
whenever i open my cursor i get this notification that there is an update available. so i wanted to see how is that possible since the workflow checks for the latest version and builds new packages based on it. so forked the repo and used another repo (oslook/cursor-ai-downloads) to fix this.